### PR TITLE
Fix error in solution file

### DIFF
--- a/PCSX2_suite.sln
+++ b/PCSX2_suite.sln
@@ -94,7 +94,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCore", "..\RTCV\Source\L
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vanguard", "..\RTCV\Source\Libraries\Vanguard\Vanguard.csproj", "{364C705E-B7AB-4A94-A59B-88899CE65958}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "..\RTCV\Source\Libraries\common\Common.csproj", "{A31C17E1-2EAB-434F-A022-20193F2CEAB7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RTCVCommon", "..\RTCV\Source\Libraries\common\Common.csproj", "{A31C17E1-2EAB-434F-A022-20193F2CEAB7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
All of my command line tooling for this repo fails with the following error:
```
Error parsing solution file at D:\Code\pcsx2-Vanguard\PCSX2_suite.sln: Exception has been thrown by the target of an invocation.  The solution file has two projects named "Common".  D:\Code\pcsx2-Vanguard\PCSX2_suite.sln
```

Both RTCV and PSXC2 have a `Common` project, which is causing this error. Fixing this is necessary for CI to be enabled for this repository. (Or for RTCV CI consuming it)

To fix this, I updated the name of one of the projects to `RTCVCommon`.

I tested this locally and my build passed. I'm not sure if there will be any deeper consequences to this change.

(I would speculate that you don't run into this issue in Visual Studio because it uses the GUIDs instead of the project names)

